### PR TITLE
replace if-condition with ternary-operator

### DIFF
--- a/WebAPI/Controllers/AuthController.cs
+++ b/WebAPI/Controllers/AuthController.cs
@@ -43,13 +43,7 @@
         public async Task<IActionResult> Login([FromBody] LoginUserQuery loginModel)
         {
             var result = await Mediator.Send(loginModel);
-
-            if (result.Success)
-            {
-                return Ok(result);
-            }
-
-            return Unauthorized(result.Message);
+            return result.Success ? Ok(result) : Unauthorized(result.Message);
         }
 
         /// <summary>
@@ -66,13 +60,7 @@
         public async Task<IActionResult> Register([FromBody] RegisterUserCommand createUser)
         {
             var result = await Mediator.Send(createUser);
-
-            if (result.Success)
-            {
-                return Ok(result);
-            }
-
-            return BadRequest(result);
+            return result.Success ? Ok(result) : BadRequest(result);
         }
 
         /// <summary>
@@ -90,13 +78,7 @@
         public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordCommand forgotPassword)
         {
             var result = await Mediator.Send(forgotPassword);
-
-            if (result.Success)
-            {
-                return Ok(result);
-            }
-
-            return BadRequest(result);
+            return result.Success ? Ok(result) : BadRequest(result);
         }
 
         /// <summary>
@@ -112,13 +94,7 @@
         public async Task<IActionResult> ChangeUserPassword([FromBody] UserChangePasswordCommand command)
         {
             var result = await Mediator.Send(command);
-
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -135,13 +111,7 @@
         public async Task<IActionResult> Verification([FromBody] VerifyCidQuery verifyCid)
         {
             var result = await Mediator.Send(verifyCid);
-
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>

--- a/WebAPI/Controllers/GroupClaimsController.cs
+++ b/WebAPI/Controllers/GroupClaimsController.cs
@@ -31,12 +31,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetGroupClaimsQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -52,12 +47,7 @@
         public async Task<IActionResult> GetById(int id)
         {
             var result = await Mediator.Send(new GetGroupClaimQuery { Id = id });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -73,12 +63,7 @@
         public async Task<IActionResult> GetGroupClaimsByGroupId(int id)
         {
             var result = await Mediator.Send(new GetGroupClaimsLookupByGroupIdQuery { GroupId = id });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -94,12 +79,7 @@
         public async Task<IActionResult> Add([FromBody] CreateGroupClaimCommand createGroupClaim)
         {
             var result = await Mediator.Send(createGroupClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -115,12 +95,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateGroupClaimCommand updateGroupClaim)
         {
             var result = await Mediator.Send(updateGroupClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -136,12 +111,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteGroupClaimCommand deleteGroupClaim)
         {
             var result = await Mediator.Send(deleteGroupClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/GroupsController.cs
+++ b/WebAPI/Controllers/GroupsController.cs
@@ -31,12 +31,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetGroupsQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -52,12 +47,7 @@
         public async Task<IActionResult> GetById(int groupId)
         {
             var result = await Mediator.Send(new GetGroupQuery { GroupId = groupId });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -73,12 +63,7 @@
         public async Task<IActionResult> Getselectedlist()
         {
             var result = await Mediator.Send(new GetGroupLookupQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -94,12 +79,7 @@
         public async Task<IActionResult> Add([FromBody] CreateGroupCommand createGroup)
         {
             var result = await Mediator.Send(createGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -115,12 +95,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateGroupCommand updateGroup)
         {
             var result = await Mediator.Send(updateGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -136,12 +111,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteGroupCommand deleteGroup)
         {
             var result = await Mediator.Send(deleteGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/LanguagesController.cs
+++ b/WebAPI/Controllers/LanguagesController.cs
@@ -31,12 +31,7 @@
         public async Task<IActionResult> GetLookupListWithCode()
         {
             var result = await Mediator.Send(new GetLanguagesLookUpWithCodeQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -52,12 +47,7 @@
         public async Task<IActionResult> GetLookupList()
         {
             var result = await Mediator.Send(new GetLanguagesLookUpQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -73,12 +63,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetLanguagesQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -94,12 +79,7 @@
         public async Task<IActionResult> GetById(int languageId)
         {
             var result = await Mediator.Send(new GetLanguageQuery { Id = languageId });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -115,12 +95,7 @@
         public async Task<IActionResult> Add([FromBody] CreateLanguageCommand createLanguage)
         {
             var result = await Mediator.Send(createLanguage);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -136,12 +111,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateLanguageCommand updateLanguage)
         {
             var result = await Mediator.Send(updateLanguage);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -157,12 +127,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteLanguageCommand deleteLanguage)
         {
             var result = await Mediator.Send(deleteLanguage);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/LogsController.cs
+++ b/WebAPI/Controllers/LogsController.cs
@@ -27,12 +27,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetLogDtoQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/OperationClaimsController.cs
+++ b/WebAPI/Controllers/OperationClaimsController.cs
@@ -30,12 +30,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetOperationClaimsQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -51,12 +46,7 @@
         public async Task<IActionResult> GetByid(int id)
         {
             var result = await Mediator.Send(new GetOperationClaimQuery() { Id = id });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -72,12 +62,7 @@
         public async Task<IActionResult> GetOperationClaimLookup()
         {
             var result = await Mediator.Send(new GetOperationClaimLookupQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -93,12 +78,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateOperationClaimCommand updateOperationClaim)
         {
             var result = await Mediator.Send(updateOperationClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -114,15 +94,7 @@
         public async Task<IActionResult> GetUserClaimsFromCache()
         {
             var result = await Mediator.Send(new GetUserClaimsFromCacheQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
-
-
-
     }
 }

--- a/WebAPI/Controllers/TranslatesController.cs
+++ b/WebAPI/Controllers/TranslatesController.cs
@@ -29,12 +29,7 @@
         public async Task<IActionResult> GetTranslatesByLang(string lang)
         {
             var result = await Mediator.Send(new GetTranslatesByLangQuery() { Lang = lang });
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -50,12 +45,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetTranslatesQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
 
@@ -72,12 +62,7 @@
         public async Task<IActionResult> GetTranslateListDto()
         {
             var result = await Mediator.Send(new GetTranslateListDtoQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -93,12 +78,7 @@
         public async Task<IActionResult> GetById(int translateId)
         {
             var result = await Mediator.Send(new GetTranslateQuery { Id = translateId });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -114,12 +94,7 @@
         public async Task<IActionResult> Add([FromBody] CreateTranslateCommand createTranslate)
         {
             var result = await Mediator.Send(createTranslate);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -135,12 +110,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateTranslateCommand updateTranslate)
         {
             var result = await Mediator.Send(updateTranslate);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -156,12 +126,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteTranslateCommand deleteTranslate)
         {
             var result = await Mediator.Send(deleteTranslate);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/UserClaimsController.cs
+++ b/WebAPI/Controllers/UserClaimsController.cs
@@ -30,12 +30,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetUserClaimsQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -51,12 +46,7 @@
         public async Task<IActionResult> GetByUserId(int userid)
         {
             var result = await Mediator.Send(new GetUserClaimLookupQuery { UserId = userid });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -72,12 +62,7 @@
         public async Task<IActionResult> GetOperationClaimByUserId(int id)
         {
             var result = await Mediator.Send(new GetUserClaimLookupByUserIdQuery { Id = id });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -93,12 +78,7 @@
         public async Task<IActionResult> Add([FromBody] CreateUserClaimCommand createUserClaim)
         {
             var result = await Mediator.Send(createUserClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -114,12 +94,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateUserClaimCommand updateUserClaim)
         {
             var result = await Mediator.Send(updateUserClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -135,12 +110,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteUserClaimCommand deleteUserClaim)
         {
             var result = await Mediator.Send(deleteUserClaim);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/UserGroupsController.cs
+++ b/WebAPI/Controllers/UserGroupsController.cs
@@ -31,12 +31,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetUserGroupsQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -52,12 +47,7 @@
         public async Task<IActionResult> GetByUserId(int userId)
         {
             var result = await Mediator.Send(new GetUserGroupLookupQuery { UserId = userId });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -73,12 +63,7 @@
         public async Task<IActionResult> GetGroupClaimsByUserId(int id)
         {
             var result = await Mediator.Send(new GetUserGroupLookupByUserIdQuery { UserId = id });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -94,12 +79,7 @@
         public async Task<IActionResult> GetUsersInGroupByGroupid(int id)
         {
             var result = await Mediator.Send(new GetUsersInGroupLookupByGroupIdQuery { GroupId = id });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -115,12 +95,7 @@
         public async Task<IActionResult> Add([FromBody] CreateUserGroupCommand createUserGroup)
         {
             var result = await Mediator.Send(createUserGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -136,12 +111,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateUserGroupCommand updateUserGroup)
         {
             var result = await Mediator.Send(updateUserGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -157,12 +127,7 @@
         public async Task<IActionResult> UpdateByGroupId([FromBody] UpdateUserGroupByGroupIdCommand updateUserGroup)
         {
             var result = await Mediator.Send(updateUserGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -178,12 +143,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteUserGroupCommand deleteUserGroup)
         {
             var result = await Mediator.Send(deleteUserGroup);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -28,12 +28,7 @@
         public async Task<IActionResult> GetList()
         {
             var result = await Mediator.Send(new GetUsersQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -49,12 +44,7 @@
         public async Task<IActionResult> GetUserLookup()
         {
             var result = await Mediator.Send(new GetUserLookupQuery());
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -70,12 +60,7 @@
         public async Task<IActionResult> GetById(int userId)
         {
             var result = await Mediator.Send(new GetUserQuery { UserId = userId });
-            if (result.Success)
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Data) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -91,12 +76,7 @@
         public async Task<IActionResult> Add([FromBody] CreateUserCommand createUser)
         {
             var result = await Mediator.Send(createUser);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -112,12 +92,7 @@
         public async Task<IActionResult> Update([FromBody] UpdateUserCommand updateUser)
         {
             var result = await Mediator.Send(updateUser);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
 
         /// <summary>
@@ -133,12 +108,7 @@
         public async Task<IActionResult> Delete([FromBody] DeleteUserCommand deleteUser)
         {
             var result = await Mediator.Send(deleteUser);
-            if (result.Success)
-            {
-                return Ok(result.Message);
-            }
-
-            return BadRequest(result.Message);
+            return result.Success ? Ok(result.Message) : BadRequest(result.Message);
         }
     }
 }


### PR DESCRIPTION
Replaced if conditions in controllers to ternary operators for readability purposes:

```javascript
if (result.Success)
{
    return Ok(result.Message);
}

return BadRequest(result.Message);
```

```javascript
return result.Success ? Ok(result.Message) : BadRequest(result.Message);
```
