### PR TITLE
API naming conventions added.

### DIFF
--- a/Business/Handlers/GroupClaims/Commands/DeleteGroupClaimCommand.cs
+++ b/Business/Handlers/GroupClaims/Commands/DeleteGroupClaimCommand.cs
@@ -14,28 +14,28 @@ namespace Business.Handlers.GroupClaims.Commands
     public class DeleteGroupClaimCommand : IRequest<IResult>
     {
         public int Id { get; set; }
+    }
 
-        public class DeleteGroupClaimCommandHandler : IRequestHandler<DeleteGroupClaimCommand, IResult>
+    public class DeleteGroupClaimCommandHandler : IRequestHandler<DeleteGroupClaimCommand, IResult>
+    {
+        private readonly IGroupClaimRepository _groupClaimRepository;
+
+        public DeleteGroupClaimCommandHandler(IGroupClaimRepository groupClaimRepository)
         {
-            private readonly IGroupClaimRepository _groupClaimRepository;
+            _groupClaimRepository = groupClaimRepository;
+        }
 
-            public DeleteGroupClaimCommandHandler(IGroupClaimRepository groupClaimRepository)
-            {
-                _groupClaimRepository = groupClaimRepository;
-            }
+        [SecuredOperation(Priority = 1)]
+        [CacheRemoveAspect()]
+        [LogAspect(typeof(FileLogger))]
+        public async Task<IResult> Handle(DeleteGroupClaimCommand request, CancellationToken cancellationToken)
+        {
+            var groupClaimToDelete = await _groupClaimRepository.GetAsync(x => x.GroupId == request.Id);
 
-            [SecuredOperation(Priority = 1)]
-            [CacheRemoveAspect()]
-            [LogAspect(typeof(FileLogger))]
-            public async Task<IResult> Handle(DeleteGroupClaimCommand request, CancellationToken cancellationToken)
-            {
-                var groupClaimToDelete = await _groupClaimRepository.GetAsync(x => x.GroupId == request.Id);
+            _groupClaimRepository.Delete(groupClaimToDelete);
+            await _groupClaimRepository.SaveChangesAsync();
 
-                _groupClaimRepository.Delete(groupClaimToDelete);
-                await _groupClaimRepository.SaveChangesAsync();
-
-                return new SuccessResult(Messages.Deleted);
-            }
+            return new SuccessResult(Messages.Deleted);
         }
     }
 }

--- a/Business/Handlers/GroupClaims/Commands/UpdateGroupClaimCommand.cs
+++ b/Business/Handlers/GroupClaims/Commands/UpdateGroupClaimCommand.cs
@@ -18,8 +18,9 @@ namespace Business.Handlers.GroupClaims.Commands
         public int Id { get; set; }
         public int GroupId { get; set; }
         public int[] ClaimIds { get; set; }
+    }
 
-        public class UpdateGroupClaimCommandHandler : IRequestHandler<UpdateGroupClaimCommand, IResult>
+    public class UpdateGroupClaimCommandHandler : IRequestHandler<UpdateGroupClaimCommand, IResult>
         {
             private readonly IGroupClaimRepository _groupClaimRepository;
 
@@ -41,5 +42,4 @@ namespace Business.Handlers.GroupClaims.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Business/Handlers/Groups/Commands/DeleteGroupCommand.cs
+++ b/Business/Handlers/Groups/Commands/DeleteGroupCommand.cs
@@ -14,8 +14,9 @@ namespace Business.Handlers.Groups.Commands
     public class DeleteGroupCommand : IRequest<IResult>
     {
         public int Id { get; set; }
+    }
 
-        public class DeleteGroupCommandHandler : IRequestHandler<DeleteGroupCommand, IResult>
+    public class DeleteGroupCommandHandler : IRequestHandler<DeleteGroupCommand, IResult>
         {
             private readonly IGroupRepository _groupRepository;
 
@@ -37,5 +38,4 @@ namespace Business.Handlers.Groups.Commands
                 return new SuccessResult(Messages.Deleted);
             }
         }
-    }
 }

--- a/Business/Handlers/Groups/Commands/UpdateGroupCommand.cs
+++ b/Business/Handlers/Groups/Commands/UpdateGroupCommand.cs
@@ -16,8 +16,8 @@ namespace Business.Handlers.Groups.Commands
     {
         public int Id { get; set; }
         public string GroupName { get; set; }
-
-        public class UpdateGroupCommandHandler : IRequestHandler<UpdateGroupCommand, IResult>
+    }
+    public class UpdateGroupCommandHandler : IRequestHandler<UpdateGroupCommand, IResult>
         {
             private readonly IGroupRepository _groupRepository;
 
@@ -42,5 +42,4 @@ namespace Business.Handlers.Groups.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Business/Handlers/Languages/Commands/DeleteLanguageCommand.cs
+++ b/Business/Handlers/Languages/Commands/DeleteLanguageCommand.cs
@@ -14,8 +14,9 @@ namespace Business.Handlers.Languages.Commands
     public class DeleteLanguageCommand : IRequest<IResult>
     {
         public int Id { get; set; }
+    }
 
-        public class DeleteLanguageCommandHandler : IRequestHandler<DeleteLanguageCommand, IResult>
+    public class DeleteLanguageCommandHandler : IRequestHandler<DeleteLanguageCommand, IResult>
         {
             private readonly ILanguageRepository _languageRepository;
             private readonly IMediator _mediator;
@@ -38,5 +39,4 @@ namespace Business.Handlers.Languages.Commands
                 return new SuccessResult(Messages.Deleted);
             }
         }
-    }
 }

--- a/Business/Handlers/Languages/Commands/UpdateLanguageCommand.cs
+++ b/Business/Handlers/Languages/Commands/UpdateLanguageCommand.cs
@@ -18,8 +18,9 @@ namespace Business.Handlers.Languages.Commands
         public int Id { get; set; }
         public string Name { get; set; }
         public string Code { get; set; }
+    }
 
-        public class UpdateLanguageCommandHandler : IRequestHandler<UpdateLanguageCommand, IResult>
+    public class UpdateLanguageCommandHandler : IRequestHandler<UpdateLanguageCommand, IResult>
         {
             private readonly ILanguageRepository _languageRepository;
             private readonly IMediator _mediator;
@@ -48,5 +49,4 @@ namespace Business.Handlers.Languages.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Business/Handlers/OperationClaims/Commands/DeleteOperationClaimCommand.cs
+++ b/Business/Handlers/OperationClaims/Commands/DeleteOperationClaimCommand.cs
@@ -14,8 +14,9 @@ namespace Business.Handlers.OperationClaims.Commands
     public class DeleteOperationClaimCommand : IRequest<IResult>
     {
         public int Id { get; set; }
+    }
 
-        public class DeleteOperationClaimCommandHandler : IRequestHandler<DeleteOperationClaimCommand, IResult>
+    public class DeleteOperationClaimCommandHandler : IRequestHandler<DeleteOperationClaimCommand, IResult>
         {
             private readonly IOperationClaimRepository _operationClaimRepository;
 
@@ -36,5 +37,4 @@ namespace Business.Handlers.OperationClaims.Commands
                 return new SuccessResult(Messages.Deleted);
             }
         }
-    }
 }

--- a/Business/Handlers/OperationClaims/Commands/UpdateOperationClaimCommand.cs
+++ b/Business/Handlers/OperationClaims/Commands/UpdateOperationClaimCommand.cs
@@ -16,8 +16,9 @@ namespace Business.Handlers.OperationClaims.Commands
         public int Id { get; set; }
         public string Alias { get; set; }
         public string Description { get; set; }
+    }
 
-        public class UpdateOperationClaimCommandHandler : IRequestHandler<UpdateOperationClaimCommand, IResult>
+    public class UpdateOperationClaimCommandHandler : IRequestHandler<UpdateOperationClaimCommand, IResult>
         {
             private readonly IOperationClaimRepository _operationClaimRepository;
 
@@ -41,5 +42,4 @@ namespace Business.Handlers.OperationClaims.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Business/Handlers/Translates/Commands/DeleteTranslateCommand.cs
+++ b/Business/Handlers/Translates/Commands/DeleteTranslateCommand.cs
@@ -14,29 +14,29 @@ namespace Business.Handlers.Translates.Commands
     public class DeleteTranslateCommand : IRequest<IResult>
     {
         public int Id { get; set; }
+    }
 
-        public class DeleteTranslateCommandHandler : IRequestHandler<DeleteTranslateCommand, IResult>
+    public class DeleteTranslateCommandHandler : IRequestHandler<DeleteTranslateCommand, IResult>
+    {
+        private readonly ITranslateRepository _translateRepository;
+        private readonly IMediator _mediator;
+
+        public DeleteTranslateCommandHandler(ITranslateRepository translateRepository, IMediator mediator)
         {
-            private readonly ITranslateRepository _translateRepository;
-            private readonly IMediator _mediator;
+            _translateRepository = translateRepository;
+            _mediator = mediator;
+        }
 
-            public DeleteTranslateCommandHandler(ITranslateRepository translateRepository, IMediator mediator)
-            {
-                _translateRepository = translateRepository;
-                _mediator = mediator;
-            }
+        [SecuredOperation(Priority = 1)]
+        [CacheRemoveAspect()]
+        [LogAspect(typeof(FileLogger))]
+        public async Task<IResult> Handle(DeleteTranslateCommand request, CancellationToken cancellationToken)
+        {
+            var translateToDelete = _translateRepository.Get(p => p.Id == request.Id);
 
-            [SecuredOperation(Priority = 1)]
-            [CacheRemoveAspect()]
-            [LogAspect(typeof(FileLogger))]
-            public async Task<IResult> Handle(DeleteTranslateCommand request, CancellationToken cancellationToken)
-            {
-                var translateToDelete = _translateRepository.Get(p => p.Id == request.Id);
-
-                _translateRepository.Delete(translateToDelete);
-                await _translateRepository.SaveChangesAsync();
-                return new SuccessResult(Messages.Deleted);
-            }
+            _translateRepository.Delete(translateToDelete);
+            await _translateRepository.SaveChangesAsync();
+            return new SuccessResult(Messages.Deleted);
         }
     }
 }

--- a/Business/Handlers/Translates/Commands/UpdateTranslateCommand.cs
+++ b/Business/Handlers/Translates/Commands/UpdateTranslateCommand.cs
@@ -19,36 +19,35 @@ namespace Business.Handlers.Translates.Commands
         public int LangId { get; set; }
         public string Value { get; set; }
         public string Code { get; set; }
+    }
+    public class UpdateTranslateCommandHandler : IRequestHandler<UpdateTranslateCommand, IResult>
+    {
+        private readonly ITranslateRepository _translateRepository;
+        private readonly IMediator _mediator;
 
-        public class UpdateTranslateCommandHandler : IRequestHandler<UpdateTranslateCommand, IResult>
+        public UpdateTranslateCommandHandler(ITranslateRepository translateRepository, IMediator mediator)
         {
-            private readonly ITranslateRepository _translateRepository;
-            private readonly IMediator _mediator;
+            _translateRepository = translateRepository;
+            _mediator = mediator;
+        }
 
-            public UpdateTranslateCommandHandler(ITranslateRepository translateRepository, IMediator mediator)
-            {
-                _translateRepository = translateRepository;
-                _mediator = mediator;
-            }
+        [SecuredOperation(Priority = 1)]
+        [ValidationAspect(typeof(CreateTranslateValidator), Priority = 2)]
+        [CacheRemoveAspect()]
+        [LogAspect(typeof(FileLogger))]
+        public async Task<IResult> Handle(UpdateTranslateCommand request, CancellationToken cancellationToken)
+        {
+            var isThereTranslateRecord = await _translateRepository.GetAsync(u => u.Id == request.Id);
 
-            [SecuredOperation(Priority = 1)]
-            [ValidationAspect(typeof(CreateTranslateValidator), Priority = 2)]
-            [CacheRemoveAspect()]
-            [LogAspect(typeof(FileLogger))]
-            public async Task<IResult> Handle(UpdateTranslateCommand request, CancellationToken cancellationToken)
-            {
-                var isThereTranslateRecord = await _translateRepository.GetAsync(u => u.Id == request.Id);
-
-                isThereTranslateRecord.Id = request.Id;
-                isThereTranslateRecord.LangId = request.LangId;
-                isThereTranslateRecord.Value = request.Value;
-                isThereTranslateRecord.Code = request.Code;
+            isThereTranslateRecord.Id = request.Id;
+            isThereTranslateRecord.LangId = request.LangId;
+            isThereTranslateRecord.Value = request.Value;
+            isThereTranslateRecord.Code = request.Code;
 
 
-                _translateRepository.Update(isThereTranslateRecord);
-                await _translateRepository.SaveChangesAsync();
-                return new SuccessResult(Messages.Updated);
-            }
+            _translateRepository.Update(isThereTranslateRecord);
+            await _translateRepository.SaveChangesAsync();
+            return new SuccessResult(Messages.Updated);
         }
     }
 }

--- a/Business/Handlers/UserClaims/Commands/DeleteUserClaimCommand.cs
+++ b/Business/Handlers/UserClaims/Commands/DeleteUserClaimCommand.cs
@@ -14,8 +14,9 @@ namespace Business.Handlers.UserClaims.Commands
     public class DeleteUserClaimCommand : IRequest<IResult>
     {
         public int Id { get; set; }
-
-        public class DeleteUserClaimCommandHandler : IRequestHandler<DeleteUserClaimCommand, IResult>
+       
+    }
+     public class DeleteUserClaimCommandHandler : IRequestHandler<DeleteUserClaimCommand, IResult>
         {
             private readonly IUserClaimRepository _userClaimRepository;
 
@@ -37,5 +38,4 @@ namespace Business.Handlers.UserClaims.Commands
                 return new SuccessResult(Messages.Deleted);
             }
         }
-    }
 }

--- a/Business/Handlers/UserClaims/Commands/UpdateUserClaimCommand.cs
+++ b/Business/Handlers/UserClaims/Commands/UpdateUserClaimCommand.cs
@@ -19,9 +19,9 @@ namespace Business.Handlers.UserClaims.Commands
         public int Id { get; set; }
         public int UserId { get; set; }
         public int[] ClaimId { get; set; }
-
-
-        public class UpdateUserClaimCommandHandler : IRequestHandler<UpdateUserClaimCommand, IResult>
+        
+    }
+    public class UpdateUserClaimCommandHandler : IRequestHandler<UpdateUserClaimCommand, IResult>
         {
             private readonly IUserClaimRepository _userClaimRepository;
             private readonly ICacheManager _cacheManager;
@@ -47,5 +47,4 @@ namespace Business.Handlers.UserClaims.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Business/Handlers/UserGroups/Commands/DeleteUserGroupCommand.cs
+++ b/Business/Handlers/UserGroups/Commands/DeleteUserGroupCommand.cs
@@ -14,8 +14,9 @@ namespace Business.Handlers.UserGroups.Commands
     public class DeleteUserGroupCommand : IRequest<IResult>
     {
         public int Id { get; set; }
+    }
 
-        public class DeleteUserGroupCommandHandler : IRequestHandler<DeleteUserGroupCommand, IResult>
+    public class DeleteUserGroupCommandHandler : IRequestHandler<DeleteUserGroupCommand, IResult>
         {
             private readonly IUserGroupRepository _userGroupRepository;
 
@@ -37,5 +38,4 @@ namespace Business.Handlers.UserGroups.Commands
                 return new SuccessResult(Messages.Deleted);
             }
         }
-    }
 }

--- a/Business/Handlers/UserGroups/Commands/UpdateUserGroupByGroupIdCommand.cs
+++ b/Business/Handlers/UserGroups/Commands/UpdateUserGroupByGroupIdCommand.cs
@@ -18,8 +18,9 @@ namespace Business.Handlers.UserGroups.Commands
         public int Id { get; set; }
         public int GroupId { get; set; }
         public int[] UserIds { get; set; }
+    }
 
-        public class UpdateUserGroupByGroupIdCommandHandler : IRequestHandler<UpdateUserGroupByGroupIdCommand, IResult>
+    public class UpdateUserGroupByGroupIdCommandHandler : IRequestHandler<UpdateUserGroupByGroupIdCommand, IResult>
         {
             private readonly IUserGroupRepository _userGroupRepository;
 
@@ -40,5 +41,4 @@ namespace Business.Handlers.UserGroups.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Business/Handlers/UserGroups/Commands/UpdateUserGroupCommand.cs
+++ b/Business/Handlers/UserGroups/Commands/UpdateUserGroupCommand.cs
@@ -18,8 +18,9 @@ namespace Business.Handlers.UserGroups.Commands
         public int Id { get; set; }
         public int UserId { get; set; }
         public int[] GroupId { get; set; }
+    }
 
-        public class UpdateUserGroupCommandHandler : IRequestHandler<UpdateUserGroupCommand, IResult>
+    public class UpdateUserGroupCommandHandler : IRequestHandler<UpdateUserGroupCommand, IResult>
         {
             private readonly IUserGroupRepository _userGroupRepository;
 
@@ -42,5 +43,4 @@ namespace Business.Handlers.UserGroups.Commands
                 return new SuccessResult(Messages.Updated);
             }
         }
-    }
 }

--- a/Entities/Dtos/UpdateGroupClaimDto.cs
+++ b/Entities/Dtos/UpdateGroupClaimDto.cs
@@ -1,0 +1,10 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateGroupClaimDto : IDto
+    {
+        public int GroupId { get; set; }
+        public int[] ClaimIds { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateGroupDto.cs
+++ b/Entities/Dtos/UpdateGroupDto.cs
@@ -1,0 +1,9 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateGroupDto : IDto
+    {
+        public string GroupName { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateLanguageDto.cs
+++ b/Entities/Dtos/UpdateLanguageDto.cs
@@ -1,0 +1,10 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateLanguageDto : IDto
+    {
+        public string Name { get; set; }
+        public string Code { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateOperationClaimDto.cs
+++ b/Entities/Dtos/UpdateOperationClaimDto.cs
@@ -1,0 +1,11 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateOperationClaimDto : IDto
+    {
+        public int Id { get; set; }
+        public string Alias { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateTranslateDto.cs
+++ b/Entities/Dtos/UpdateTranslateDto.cs
@@ -1,0 +1,12 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateTranslateDto : IDto
+    {
+        public int Id { get; set; }
+        public int LangId { get; set; }
+        public string Value { get; set; }
+        public string Code { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateUserClaimDto.cs
+++ b/Entities/Dtos/UpdateUserClaimDto.cs
@@ -1,0 +1,10 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateUserClaimDto : IDto
+    {
+        public int UserId { get; set; }
+        public int[] ClaimIds { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateUserDto.cs
+++ b/Entities/Dtos/UpdateUserDto.cs
@@ -1,0 +1,13 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateUserDto : IDto
+    {
+        public string Email { get; set; }
+        public string FullName { get; set; }
+        public string MobilePhones { get; set; }
+        public string Address { get; set; }
+        public string Notes { get; set; }
+    }
+}

--- a/Entities/Dtos/UpdateUserGroupByGroupIdDto.cs
+++ b/Entities/Dtos/UpdateUserGroupByGroupIdDto.cs
@@ -1,0 +1,10 @@
+using Core.Entities;
+
+namespace Entities.Dtos
+{
+    public class UpdateUserGroupByGroupIdDto : IDto
+    {
+        public int GroupId { get; set; }
+        public int[] UserIds { get; set; }
+    }
+}

--- a/Tests/Business/Services/Authentication/TokenTests.cs
+++ b/Tests/Business/Services/Authentication/TokenTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Business.Services.Authentication
     public class TokenTests : BaseIntegrationTest
     {
         private const string AuthenticationScheme = "Bearer";
-        private const string RequestUri = "api/users/";
+        private const string RequestUri = "api/users";
 
         [Test]
         public async Task TokenAuthorizeTest()

--- a/Tests/Business/Services/Authentication/TokenTests.cs
+++ b/Tests/Business/Services/Authentication/TokenTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Business.Services.Authentication
     public class TokenTests : BaseIntegrationTest
     {
         private const string AuthenticationScheme = "Bearer";
-        private const string RequestUri = "api/users/getall";
+        private const string RequestUri = "api/users/";
 
         [Test]
         public async Task TokenAuthorizeTest()

--- a/Tests/Business/Services/Authentication/TokenTests.cs
+++ b/Tests/Business/Services/Authentication/TokenTests.cs
@@ -15,7 +15,7 @@ namespace Tests.Business.Services.Authentication
     public class TokenTests : BaseIntegrationTest
     {
         private const string AuthenticationScheme = "Bearer";
-        private const string RequestUri = "api/users";
+        private const string RequestUri = "api/v1/users";
 
         [Test]
         public async Task TokenAuthorizeTest()

--- a/Tests/WebAPI/UsersControllerTests.cs
+++ b/Tests/WebAPI/UsersControllerTests.cs
@@ -18,7 +18,7 @@ namespace Tests.WebAPI
         public async Task GetAll()
         {
             const string authenticationScheme = "Bearer";
-            const string requestUri = "api/users/";
+            const string requestUri = "api/users";
 
             // Arrange
             var token = MockJwtTokens.GenerateJwtToken(ClaimsData.GetClaims());

--- a/Tests/WebAPI/UsersControllerTests.cs
+++ b/Tests/WebAPI/UsersControllerTests.cs
@@ -18,7 +18,7 @@ namespace Tests.WebAPI
         public async Task GetAll()
         {
             const string authenticationScheme = "Bearer";
-            const string requestUri = "api/users/getall";
+            const string requestUri = "api/users/";
 
             // Arrange
             var token = MockJwtTokens.GenerateJwtToken(ClaimsData.GetClaims());

--- a/Tests/WebAPI/UsersControllerTests.cs
+++ b/Tests/WebAPI/UsersControllerTests.cs
@@ -18,7 +18,7 @@ namespace Tests.WebAPI
         public async Task GetAll()
         {
             const string authenticationScheme = "Bearer";
-            const string requestUri = "api/users";
+            const string requestUri = "api/v1/users";
 
             // Arrange
             var token = MockJwtTokens.GenerateJwtToken(ClaimsData.GetClaims());

--- a/UiPreparation/UI/src/app/core/components/admin/group/Services/Group.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/group/Services/Group.service.ts
@@ -10,49 +10,46 @@ import { LookUp } from 'app/core/models/lookUp';
 })
 export class GroupService {
 
-  constructor(private httpClient: HttpClient) { }
+  constructor(private readonly _httpClient: HttpClient) { }
 
   getGroupList(): Observable<Group[]> {
 
-    return this.httpClient.get<Group[]>(environment.getApiUrl + "/Groups/getall")
+    return this._httpClient.get<Group[]>(environment.getApiUrl + "/groups/")
   }
 
   getGroupById(id: number): Observable<Group> {
-    return this.httpClient.get<Group>(environment.getApiUrl + "/Groups/getbyid?groupId=" + id);
+    return this._httpClient.get<Group>(environment.getApiUrl + `/groups/${id}`);
   }
 
   getGroupClaims(id: number): Observable<LookUp[]> {
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/GroupClaims/getgroupclaimsbygroupid?id=" + id); 
+    return this._httpClient.get<LookUp[]>(environment.getApiUrl + `/group-claims/groups/${id}`);
   }
 
-  getGroupUsers(id:number):Observable<LookUp[]>{
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/UserGroups/getusersingroupbygroupid?id=" + id);  
+  getGroupUsers(id: number): Observable<LookUp[]> {
+    return this._httpClient.get<LookUp[]>(environment.getApiUrl + `/user-groups/groups/${id}/users`);
   }
 
-  addGroup(group:Group):Observable<any>{
-
-    var result = this.httpClient.post(environment.getApiUrl + "/groups/", group, { responseType: 'text' });
+  addGroup(group: Group): Observable<any> {
+    var result = this._httpClient.post(environment.getApiUrl + "/groups/", group, { responseType: 'text' });
     return result;
   }
 
-  updateGroup(group:Group):Observable<any> {
-    var result = this.httpClient.put(environment.getApiUrl + "/groups/", group, { responseType: 'text' });
-    return result; 
-  }
-
-  deleteGroup(id:number){
-    return this.httpClient.request('delete', environment.getApiUrl + "/groups/", { body: {Id:id} });
-  }
-
-  saveGroupClaims(groupId:number,claims:number[] ):Observable<any> {
-    var result = this.httpClient.put(environment.getApiUrl + "/GroupClaims/", {GroupId:groupId, ClaimIds:claims }, { responseType: 'text' });
+  updateGroup(group: Group): Observable<any> {
+    var result = this._httpClient.put(environment.getApiUrl + `/groups/${group.id}`, group, { responseType: 'text' });
     return result;
   }
 
-  saveGroupUsers(groupId:number,userIds:number[] ):Observable<any> {
-    var result = this.httpClient.put(environment.getApiUrl + "/UserGroups/updatebygroupid", {GroupId:groupId, UserIds:userIds }, { responseType: 'text' });
+  deleteGroup(id: number) {
+    return this._httpClient.request('delete', environment.getApiUrl + `/groups/${id}`);
+  }
+
+  saveGroupClaims(groupId: number, claims: number[]): Observable<any> {
+    var result = this._httpClient.put(environment.getApiUrl + `/group-claims/${groupId}`, { ClaimIds: claims }, { responseType: 'text' });
     return result;
   }
 
-
+  saveGroupUsers(groupId: number, userIds: number[]): Observable<any> {
+    var result = this._httpClient.put(environment.getApiUrl + `/user-groups/groups/${groupId}`, { UserIds: userIds }, { responseType: 'text' });
+    return result;
+  }
 }

--- a/UiPreparation/UI/src/app/core/components/admin/language/services/language.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/language/services/language.service.ts
@@ -3,31 +3,34 @@ import { ApiUrl } from 'app/core/constants/api-url';
 import { HttpEntityRepositoryService } from 'app/core/services/http-entity-repository.service';
 import { Observable } from 'rxjs';
 import { Language } from '../Models/Language';
+import { HttpClient } from '@angular/common/http';
+
 
 @Injectable({
   providedIn: 'root'
 })
 export class LanguageService {
 
-  constructor(private service: HttpEntityRepositoryService<any>) { }
+  constructor(private service: HttpEntityRepositoryService<any>,
+    private readonly _httpClient: HttpClient) { }
 
   getLanguageList(): Observable<Language[]> {
-    return this.service.getAll(ApiUrl.GETALL_LANGUAGES);
+    return this._httpClient.getAll('/languages/');
   }
 
   getLanguage(id: number): Observable<Language> {
-    return this.service.get(ApiUrl.GET_LANGUAGES,id);
+    return this._httpClient.get(`/languages/${id}`);
   }
 
   addLanguage(language: Language): Observable<any> {
-    return this.service.add(ApiUrl.LANGUAGES, language);
+    return this._httpClient.add('/languages/', language);
   }
 
   updateLanguage(language: Language): Observable<any> {
-    return this.service.update(ApiUrl.LANGUAGES, language);
+    return this._httpClient.update(`/languages/${language.id}`, language);
   }
 
   deleteLanguage(id: number) {
-    return this.service.delete(ApiUrl.LANGUAGES,id);
+    return this._httpClient.delete(`/languages/${id}`);
   }
 }

--- a/UiPreparation/UI/src/app/core/components/admin/log/services/logdto.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/log/services/logdto.service.ts
@@ -10,12 +10,12 @@ import { environment } from 'environments/environment';
 })
 export class LogDtoService {
 
-  constructor(private httpClient: HttpClient) { }
+  constructor(private readonly _httpClient: HttpClient) { }
 
 
   getLogDtoList(): Observable<LogDto[]> {
 
-    return this.httpClient.get<LogDto[]>(environment.getApiUrl + '/logs/getall')
+    return this._httpClient.get<LogDto[]>(environment.getApiUrl + '/logs/')
   }
 
 }

--- a/UiPreparation/UI/src/app/core/components/admin/login/Services/Auth.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/login/Services/Auth.service.ts
@@ -68,7 +68,7 @@ export class AuthService {
 
     if ((this.claims == undefined || this.claims.length == 0) && this.storageService.getToken() != null && this.loggedIn() ) {
 
-      this.httpClient.get<string[]>(environment.getApiUrl + "/OperationClaims/getuserclaimsfromcache").subscribe(data => {
+      this.httpClient.get<string[]>(environment.getApiUrl + "/operation-claims/cache").subscribe(data => {
         this.claims =data;
       })
 

--- a/UiPreparation/UI/src/app/core/components/admin/login/services/token.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/login/services/token.service.ts
@@ -15,7 +15,7 @@ constructor(private httpClient:HttpClient,private storageService:LocalStorageSer
 refreshToken(){
   if(this.storageService.getItem("refreshToken") !== null)
   return this.httpClient
-      .post<any>(environment.getApiUrl + "/Auth/RefreshToken",{refreshToken:this.storageService.getItem("refreshToken")})
+      .post<any>(environment.getApiUrl + "/Auth/refresh-token",{refreshToken:this.storageService.getItem("refreshToken")})
       .pipe(tap(res => {
         if(res.success){
           this.storageService.setToken(res.data.token);

--- a/UiPreparation/UI/src/app/core/components/admin/operationclaim/services/operationclaim.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/operationclaim/services/operationclaim.service.ts
@@ -9,20 +9,20 @@ import { OperationClaim } from '../Models/OperationClaim';
 })
 export class OperationClaimService {
 
-  constructor(private httpClient: HttpClient) { }
+  constructor(private readonly _httpClient: HttpClient) { }
 
 
   getOperationClaimList(): Observable<OperationClaim[]> {
 
-    return this.httpClient.get<OperationClaim[]>(environment.getApiUrl + '/operationClaims/getall')
+    return this._httpClient.get<OperationClaim[]>(environment.getApiUrl + '/operation-claims/')
   }
 
   getOperationClaim(id: number): Observable<OperationClaim> {
-    return this.httpClient.get<OperationClaim>(environment.getApiUrl  + '/operationClaims/getbyid?id='+id)
+    return this._httpClient.get<OperationClaim>(environment.getApiUrl  + `/operation-claims/${id}`)
   }
 
   updateOperationClaim(operationClaim: OperationClaim): Observable<any> {
-    return this.httpClient.put(environment.getApiUrl  + '/operationClaims/', operationClaim, { responseType: 'text' });
+    return this._httpClient.put(environment.getApiUrl  + `/operation-claims/${operationClaim.id}`, operationClaim, { responseType: 'text' });
 
   }
 

--- a/UiPreparation/UI/src/app/core/components/admin/translate/services/translate.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/translate/services/translate.service.ts
@@ -9,31 +9,29 @@ import { Translate } from '../Models/Translate';
 })
 export class TranslateService {
 
-  constructor(private httpClient: HttpClient) { }
+  constructor(private readonly _httpClient: HttpClient) { }
 
 
   getTranslateList(): Observable<Translate[]> {
 
-    return this.httpClient.get<Translate[]>(environment.getApiUrl + '/translates/gettranslatelistdto')
+    return this._httpClient.get<Translate[]>(environment.getApiUrl + '/translates/dtos')
   }
 
   getTranslate(id: number): Observable<Translate> {
-    return this.httpClient.get<Translate>(environment.getApiUrl + '/translates/getbyid?translateId='+id)
+    return this._httpClient.get<Translate>(environment.getApiUrl + `/translates/${id}`)
   }
 
   addTranslate(translate: Translate): Observable<any> {
 
-    return this.httpClient.post(environment.getApiUrl + '/translates/', translate, { responseType: 'text' });
+    return this._httpClient.post(environment.getApiUrl + '/translates/', translate, { responseType: 'text' });
   }
 
   updateTranslate(translate: Translate): Observable<any> {
-    return this.httpClient.put(environment.getApiUrl + '/translates/', translate, { responseType: 'text' });
+    return this._httpClient.put(environment.getApiUrl + '/translates/', translate, { responseType: 'text' });
 
   }
 
   deleteTranslate(id: number) {
-    return this.httpClient.request('delete', environment.getApiUrl + '/translates/', { body: { Id: id } });
+    return this._httpClient.request('delete', environment.getApiUrl + `/translates/${id}`);
   }
-
-
 }

--- a/UiPreparation/UI/src/app/core/components/admin/user/Services/User.service.ts
+++ b/UiPreparation/UI/src/app/core/components/admin/user/Services/User.service.ts
@@ -16,13 +16,13 @@ export class UserService {
 
   getUserList(): Observable<User[]> {
 
-    return this.httpClient.get<User[]>(environment.getApiUrl + "/users/getall");
+    return this.httpClient.get<User[]>(environment.getApiUrl + "/users/");
 
   }
 
   getUserById(id: number): Observable<User> {
 
-    return this.httpClient.get<User>(environment.getApiUrl + "/users/getbyid?userId=" + id);
+    return this.httpClient.get<User>(environment.getApiUrl + `/users/${id}`);
   }
 
 
@@ -34,37 +34,37 @@ export class UserService {
 
   updateUser(user:User):Observable<any> {
 
-    var result = this.httpClient.put(environment.getApiUrl + "/users/", user, { responseType: 'text' });
+    var result = this.httpClient.put(environment.getApiUrl + `/users/${user.userId}`, user, { responseType: 'text' });
     return result;
   }
 
   deleteUser(id: number) {
-    return this.httpClient.request('delete', environment.getApiUrl + "/users/", { body: {userId:id} });
+    return this.httpClient.request('delete', environment.getApiUrl + `/users/${id}`);
   }
 
   getUserGroupPermissions(userId:number):Observable<LookUp[]>{
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/UserGroups/getusergroupbyuserid?id=" + userId);
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + `/user-groups/users/${userId}/groups`);
   }
 
   getUserClaims(userId:number){
-     return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/UserClaims/getoperationclaimbyuserid?id=" + userId);
+     return this.httpClient.get<LookUp[]>(environment.getApiUrl + `/user-claims/users${userId}`);
   }
 
   saveUserClaims(userId:number,claims:number[] ):Observable<any> {
 
-    var result = this.httpClient.put(environment.getApiUrl + "/UserClaims/", {UserId:userId, ClaimId:claims }, { responseType: 'text' });
+    var result = this.httpClient.put(environment.getApiUrl + `/user-claims/${userId}`, { ClaimId:claims }, { responseType: 'text' });
     return result;
 
   }
 
   saveUserGroupPermissions(userId:number, groups:number[]):Observable<any> {
-    var result = this.httpClient.put(environment.getApiUrl + "/UserGroups/", {UserId:userId, GroupId:groups }, { responseType: 'text' });
+    var result = this.httpClient.put(environment.getApiUrl + `/user-groups/${userId}`, { GroupId:groups }, { responseType: 'text' });
     return result;
 
   }
 
   saveUserPassword(command:PasswordDto):Observable<any>{
-    var result = this.httpClient.put(environment.getApiUrl + "/Auth/changeuserpassword", command, { responseType: 'text' });
+    var result = this.httpClient.put(environment.getApiUrl + "/Auth/user-password", command, { responseType: 'text' });
     return result;
   }
 

--- a/UiPreparation/UI/src/app/core/constants/api-url.ts
+++ b/UiPreparation/UI/src/app/core/constants/api-url.ts
@@ -1,5 +1,5 @@
 export class ApiUrl {
-    public static GETALL_LANGUAGES = "/languages/getall";
-    public static GET_LANGUAGES = "/languages/getbyid?languageId=";
+    public static GETALL_LANGUAGES = "/languages/";
+    public static GET_LANGUAGES = "/languages/";
     public static LANGUAGES = "/languages/";
 }

--- a/UiPreparation/UI/src/app/core/services/LookUp.service.ts
+++ b/UiPreparation/UI/src/app/core/services/LookUp.service.ts
@@ -14,20 +14,20 @@ export class LookUpService {
 
   getGroupLookUp(): Observable<LookUp[]> {
 
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Groups/getgrouplookup")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Groups/lookups")
   }
 
   getOperationClaimLookUp(): Observable<LookUp[]> {
 
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/OperationClaims/getoperationclaimlookup")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/OperationClaims/lookups")
   }
 
   getUserLookUp():Observable<LookUp[]>{
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Users/getuserlookup")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Users/lookups")
   }
 
   getLanguageLookup():Observable<LookUp[]>{
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Languages/getlookup")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Languages/lookups")
   }
 
 }

--- a/UiPreparation/UI/src/app/core/services/LookUp.service.ts
+++ b/UiPreparation/UI/src/app/core/services/LookUp.service.ts
@@ -14,20 +14,20 @@ export class LookUpService {
 
   getGroupLookUp(): Observable<LookUp[]> {
 
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Groups/lookups")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/groups/lookups")
   }
 
   getOperationClaimLookUp(): Observable<LookUp[]> {
 
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/OperationClaims/lookups")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/operation-claims/lookups")
   }
 
   getUserLookUp():Observable<LookUp[]>{
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Users/lookups")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/users/lookups")
   }
 
   getLanguageLookup():Observable<LookUp[]>{
-    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/Languages/lookups")
+    return this.httpClient.get<LookUp[]>(environment.getApiUrl + "/languages/lookups")
   }
 
 }

--- a/UiPreparation/UI/src/app/core/services/Translation.service.ts
+++ b/UiPreparation/UI/src/app/core/services/Translation.service.ts
@@ -15,6 +15,6 @@ export class TranslationService implements TranslateLoader {
   constructor(private http: HttpClient) { }
 
   getTranslation(lang: string): Observable<any> {
-   return this.http.get(environment.getApiUrl + '/translates/gettranslatesbylang?lang='+lang,{responseType:"json"}); 
+    return this.http.get(environment.getApiUrl + '/translates/languages', { params: { lang }, responseType: "json" });
   }
 }

--- a/UiPreparation/UI/src/environments/environment.ts
+++ b/UiPreparation/UI/src/environments/environment.ts
@@ -5,7 +5,7 @@
 
 export const environment = {
   production: false,
-  getApiUrl: "https://localhost:5001/api",
+  getApiUrl: `https://localhost:5001/api/v1`,
   getDropDownSetting: {
     singleSelection: false,
     idField: 'id',

--- a/WebAPI/Controllers/AuthController.cs
+++ b/WebAPI/Controllers/AuthController.cs
@@ -39,7 +39,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IDataResult<AccessToken>))]
         [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(string))]
-        [HttpPost("Login")]
+        [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginUserQuery loginModel)
         {
             var result = await Mediator.Send(loginModel);
@@ -51,7 +51,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IDataResult<AccessToken>))]
         [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(string))]
-        [HttpPost("RefreshToken")]
+        [HttpPost("refresh-token")]
         public async Task<IActionResult> LoginWithRefreshToken([FromBody] LoginWithRefreshTokenQuery command)
         {
             var result = await Mediator.Send(command);
@@ -85,7 +85,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IResult))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(IResult))]
-        [HttpPut("forgotpassword")]
+        [HttpPut("forgot-password")]
         public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordCommand forgotPassword)
         {
             return GetResponseOnlyResult(await Mediator.Send(forgotPassword));
@@ -100,7 +100,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut("changeuserpassword")]
+        [HttpPut("user-password")]
         public async Task<IActionResult> ChangeUserPassword([FromBody] UserChangePasswordCommand command)
         {
             return GetResponseOnlyResultMessage(await Mediator.Send(command));

--- a/WebAPI/Controllers/AuthController.cs
+++ b/WebAPI/Controllers/AuthController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/AuthController.cs
+++ b/WebAPI/Controllers/AuthController.cs
@@ -15,7 +15,7 @@ namespace WebAPI.Controllers
     /// <summary>
     /// Make it Authorization operations
     /// </summary>
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     public class AuthController : BaseApiController
     {

--- a/WebAPI/Controllers/GroupClaimsController.cs
+++ b/WebAPI/Controllers/GroupClaimsController.cs
@@ -6,6 +6,7 @@ using Core.Entities.Concrete;
 using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/GroupClaimsController.cs
+++ b/WebAPI/Controllers/GroupClaimsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     ///
     /// </summary>
     ///
-    [Route("api/group-claims")]
+    [Route("api/v{version:apiVersion}/group-claims")]
     [ApiController]
     public class GroupClaimsController : BaseApiController
     {

--- a/WebAPI/Controllers/GroupClaimsController.cs
+++ b/WebAPI/Controllers/GroupClaimsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     ///
     /// </summary>
     ///
-    [Route("api/[controller]")]
+    [Route("api/group-claims")]
     [ApiController]
     public class GroupClaimsController : BaseApiController
     {

--- a/WebAPI/Controllers/GroupClaimsController.cs
+++ b/WebAPI/Controllers/GroupClaimsController.cs
@@ -27,7 +27,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<GroupClaim>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultMessage(await Mediator.Send(new GetGroupClaimsQuery()));
@@ -42,8 +42,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GroupClaim))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyid")]
-        public async Task<IActionResult> GetById(int id)
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById([FromRoute] int id)
         {
             return GetResponseOnlyResultMessage(await Mediator.Send(new GetGroupClaimQuery { Id = id }));
         }
@@ -57,8 +57,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getgroupclaimsbygroupid")]
-        public async Task<IActionResult> GetGroupClaimsByGroupId(int id)
+        [HttpGet("groups/{id}")]
+        public async Task<IActionResult> GetGroupClaimsByGroupId([FromRoute]int id)
         {
             return GetResponseOnlyResultData(
                 await Mediator.Send(new GetGroupClaimsLookupByGroupIdQuery { GroupId = id }));
@@ -88,10 +88,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateGroupClaimCommand updateGroupClaim)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateGroupClaimDto updateGroupClaimDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateGroupClaim));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateGroupClaimCommand{ Id = id, GroupId = updateGroupClaimDto.GroupId, ClaimIds = updateGroupClaimDto.ClaimIds }));
         }
 
         /// <summary>
@@ -103,10 +103,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteGroupClaimCommand deleteGroupClaim)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteGroupClaim));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteGroupClaimCommand{Id = id}));
         }
     }
 }

--- a/WebAPI/Controllers/GroupsController.cs
+++ b/WebAPI/Controllers/GroupsController.cs
@@ -27,7 +27,7 @@ namespace WebAPI.Controllers
         // [Produces("application/json","text/plain")]
         // [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<Group>))]
         // [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetGroupsQuery()));
@@ -42,7 +42,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Group))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyid")]
+        [HttpGet("{id}")]
         public async Task<IActionResult> GetById(int groupId)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetGroupQuery { GroupId = groupId }));
@@ -57,7 +57,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getgrouplookup")]
+        [HttpGet("lookups")]
         public async Task<IActionResult> Getselectedlist()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetGroupLookupQuery()));
@@ -87,10 +87,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateGroupCommand updateGroup)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateGroupDto updateGroupDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateGroup));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateGroupCommand{ Id = id, GroupName = updateGroupDto.GroupName }));
         }
 
         /// <summary>
@@ -102,10 +102,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteGroupCommand deleteGroup)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteGroup));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteGroupCommand{ Id = id }));
         }
     }
 }

--- a/WebAPI/Controllers/GroupsController.cs
+++ b/WebAPI/Controllers/GroupsController.cs
@@ -6,6 +6,7 @@ using Core.Entities.Concrete;
 using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/GroupsController.cs
+++ b/WebAPI/Controllers/GroupsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     public class GroupsController : BaseApiController
     {

--- a/WebAPI/Controllers/GroupsController.cs
+++ b/WebAPI/Controllers/GroupsController.cs
@@ -44,7 +44,7 @@ namespace WebAPI.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Group))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [HttpGet("{id}")]
-        public async Task<IActionResult> GetById(int groupId)
+        public async Task<IActionResult> GetById([FromRoute] int groupId)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetGroupQuery { GroupId = groupId }));
         }

--- a/WebAPI/Controllers/LanguagesController.cs
+++ b/WebAPI/Controllers/LanguagesController.cs
@@ -7,6 +7,7 @@ using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/LanguagesController.cs
+++ b/WebAPI/Controllers/LanguagesController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     /// <summary>
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     public class LanguagesController : BaseApiController
     {

--- a/WebAPI/Controllers/LanguagesController.cs
+++ b/WebAPI/Controllers/LanguagesController.cs
@@ -27,7 +27,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getlookupwithcode")]
+        [HttpGet("codes")]
         public async Task<IActionResult> GetLookupListWithCode()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetLanguagesLookUpWithCodeQuery()));
@@ -42,7 +42,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getlookup")]
+        [HttpGet("lookups")]
         public async Task<IActionResult> GetLookupList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetLanguagesLookUpQuery()));
@@ -57,7 +57,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<Language>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetLanguagesQuery()));
@@ -72,8 +72,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Language))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyid")]
-        public async Task<IActionResult> GetById(int languageId)
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById([FromRoute]int languageId)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetLanguageQuery { Id = languageId }));
         }
@@ -102,10 +102,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateLanguageCommand updateLanguage)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateLanguageDto updateLanguageDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateLanguage));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateLanguageCommand{Id = id, Name = updateLanguageDto.Name, Code = updateLanguageDto.Code}));
         }
 
         /// <summary>
@@ -117,10 +117,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteLanguageCommand deleteLanguage)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteLanguage));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteLanguageCommand{}));
         }
     }
 }

--- a/WebAPI/Controllers/LogsController.cs
+++ b/WebAPI/Controllers/LogsController.cs
@@ -4,6 +4,7 @@ using Business.Handlers.Logs.Queries;
 using Core.Entities.Concrete;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/LogsController.cs
+++ b/WebAPI/Controllers/LogsController.cs
@@ -23,7 +23,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<OperationClaim>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetLogDtoQuery()));

--- a/WebAPI/Controllers/LogsController.cs
+++ b/WebAPI/Controllers/LogsController.cs
@@ -11,7 +11,7 @@ namespace WebAPI.Controllers
     /// <summary>
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     public class LogsController : BaseApiController
     {

--- a/WebAPI/Controllers/OperationClaimsController.cs
+++ b/WebAPI/Controllers/OperationClaimsController.cs
@@ -6,6 +6,7 @@ using Core.Entities.Concrete;
 using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/OperationClaimsController.cs
+++ b/WebAPI/Controllers/OperationClaimsController.cs
@@ -26,7 +26,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<OperationClaim>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetOperationClaimsQuery()));
@@ -41,8 +41,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OperationClaim))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyid")]
-        public async Task<IActionResult> GetByid(int id)
+        [HttpGet("{id}}")]
+        public async Task<IActionResult> GetByid([FromRoute]int id)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetOperationClaimQuery() { Id = id }));
         }
@@ -56,7 +56,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getoperationclaimlookup")]
+        [HttpGet("lookups")]
         public async Task<IActionResult> GetOperationClaimLookup()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetOperationClaimLookupQuery()));
@@ -71,10 +71,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateOperationClaimCommand updateOperationClaim)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateOperationClaimDto updateOperationClaimDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateOperationClaim));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateOperationClaimCommand{Id = id, Alias = updateOperationClaimDto.Alias, Description = updateOperationClaimDto.Description}));
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<OperationClaim>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getuserclaimsfromcache")]
+        [HttpGet("cache")]
         public async Task<IActionResult> GetUserClaimsFromCache()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserClaimsFromCacheQuery()));

--- a/WebAPI/Controllers/OperationClaimsController.cs
+++ b/WebAPI/Controllers/OperationClaimsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/[controller]")]
+    [Route("api/operation-claims")]
     [ApiController]
     public class OperationClaimsController : BaseApiController
     {
@@ -42,7 +42,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OperationClaim))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("{id}}")]
+        [HttpGet("{id}")]
         public async Task<IActionResult> GetByid([FromRoute]int id)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetOperationClaimQuery() { Id = id }));

--- a/WebAPI/Controllers/OperationClaimsController.cs
+++ b/WebAPI/Controllers/OperationClaimsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/operation-claims")]
+    [Route("api/v{version:apiVersion}/operation-claims")]
     [ApiController]
     public class OperationClaimsController : BaseApiController
     {

--- a/WebAPI/Controllers/TranslatesController.cs
+++ b/WebAPI/Controllers/TranslatesController.cs
@@ -6,6 +6,7 @@ using Core.Entities.Concrete;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/TranslatesController.cs
+++ b/WebAPI/Controllers/TranslatesController.cs
@@ -13,7 +13,7 @@ namespace WebAPI.Controllers
     /// <summary>
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     public class TranslatesController : BaseApiController
     {

--- a/WebAPI/Controllers/TranslatesController.cs
+++ b/WebAPI/Controllers/TranslatesController.cs
@@ -25,8 +25,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("gettranslatesbylang")]
-        public async Task<IActionResult> GetTranslatesByLang(string lang)
+        [HttpGet("languages/{lang}")]
+        public async Task<IActionResult> GetTranslatesByLang([FromRoute] string lang)
         {
             return GetResponseOnlyResultMessage(await Mediator.Send(new GetTranslatesByLangQuery() { Lang = lang }));
         }
@@ -40,7 +40,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<Translate>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetTranslatesQuery()));
@@ -55,7 +55,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<Translate>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("gettranslatelistdto")]
+        [HttpGet("dtos")]
         public async Task<IActionResult> GetTranslateListDto()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetTranslateListDtoQuery()));
@@ -70,8 +70,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Translate))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyid")]
-        public async Task<IActionResult> GetById(int translateId)
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById([FromRoute]int translateId)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetTranslateQuery { Id = translateId }));
         }
@@ -100,10 +100,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateTranslateCommand updateTranslate)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateTranslateDto updateTranslateDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateTranslate));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateTranslateCommand{Id = id, LangId = updateTranslateDto.LangId, Value = updateTranslateDto.Value,Code = updateTranslateDto.Code }));
         }
 
         /// <summary>
@@ -115,10 +115,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteTranslateCommand deleteTranslate)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteTranslate));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteTranslateCommand{Id = id}));
         }
     }
 }

--- a/WebAPI/Controllers/UserClaimsController.cs
+++ b/WebAPI/Controllers/UserClaimsController.cs
@@ -6,6 +6,7 @@ using Core.Entities.Concrete;
 using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/UserClaimsController.cs
+++ b/WebAPI/Controllers/UserClaimsController.cs
@@ -26,7 +26,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserClaim>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserClaimsQuery()));
@@ -41,8 +41,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserClaim>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyuserid")]
-        public async Task<IActionResult> GetByUserId(int userid)
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetByUserId([FromRoute]int userid)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserClaimLookupQuery { UserId = userid }));
         }
@@ -56,8 +56,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getoperationclaimbyuserid")]
-        public async Task<IActionResult> GetOperationClaimByUserId(int id)
+        [HttpGet("users/{id}")]
+        public async Task<IActionResult> GetOperationClaimByUserId([FromRoute]int id)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserClaimLookupByUserIdQuery { Id = id }));
         }
@@ -86,10 +86,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateUserClaimCommand updateUserClaim)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateUserClaimDto updateUserClaimDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateUserClaim));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new  UpdateUserClaimCommand{Id = id, UserId = updateUserClaimDto.UserId, ClaimId = updateUserClaimDto.ClaimIds}));
         }
 
         /// <summary>
@@ -101,10 +101,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteUserClaimCommand deleteUserClaim)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteUserClaim));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteUserClaimCommand{Id = id}));
         }
     }
 }

--- a/WebAPI/Controllers/UserClaimsController.cs
+++ b/WebAPI/Controllers/UserClaimsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/user-claims")]
+    [Route("api/v{version:apiVersion}/user-claims")]
     [ApiController]
     public class UserClaimsController : BaseApiController
     {

--- a/WebAPI/Controllers/UserClaimsController.cs
+++ b/WebAPI/Controllers/UserClaimsController.cs
@@ -14,7 +14,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/[controller]")]
+    [Route("api/user-claims")]
     [ApiController]
     public class UserClaimsController : BaseApiController
     {

--- a/WebAPI/Controllers/UserGroupsController.cs
+++ b/WebAPI/Controllers/UserGroupsController.cs
@@ -7,6 +7,7 @@ using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/UserGroupsController.cs
+++ b/WebAPI/Controllers/UserGroupsController.cs
@@ -15,7 +15,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/[controller]")]
+    [Route("api/user-groups")]
     [ApiController]
     public class UserGroupsController : BaseApiController
     {
@@ -48,6 +48,22 @@ namespace WebAPI.Controllers
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserGroupLookupQuery { UserId = userId }));
         }
+
+        /// <summary>
+        /// It brings the details according to its id.
+        /// </summary>
+        /// <remarks>bla bla bla </remarks>
+        /// <return>UserGroups List</return>
+        /// <response code="200"></response>
+        [Produces("application/json", "text/plain")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserGroup>))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [HttpGet("users/{id}/groups")]
+        public async Task<IActionResult> GetGroupClaimsByUserId([FromRoute]int id)
+        {
+            return GetResponseOnlyResultData(await Mediator.Send(new GetUserGroupLookupByUserIdQuery { UserId = id }));
+        }
+
 
         /// <summary>
         /// It brings the details according to its id.

--- a/WebAPI/Controllers/UserGroupsController.cs
+++ b/WebAPI/Controllers/UserGroupsController.cs
@@ -15,7 +15,7 @@ namespace WebAPI.Controllers
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
     ///
-    [Route("api/user-groups")]
+    [Route("api/v{version:apiVersion}/user-groups")]
     [ApiController]
     public class UserGroupsController : BaseApiController
     {

--- a/WebAPI/Controllers/UserGroupsController.cs
+++ b/WebAPI/Controllers/UserGroupsController.cs
@@ -27,7 +27,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserGroup>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserGroupsQuery()));
@@ -41,9 +41,9 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyuserid")]
+        [HttpGet("users/{id}")]
         [AllowAnonymous]
-        public async Task<IActionResult> GetByUserId(int userId)
+        public async Task<IActionResult> GetByUserId([FromRoute]int userId)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserGroupLookupQuery { UserId = userId }));
         }
@@ -57,23 +57,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserGroup>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getusergroupbyuserid")]
-        public async Task<IActionResult> GetGroupClaimsByUserId(int id)
-        {
-            return GetResponseOnlyResultData(await Mediator.Send(new GetUserGroupLookupByUserIdQuery { UserId = id }));
-        }
-
-        /// <summary>
-        /// It brings the details according to its id.
-        /// </summary>
-        /// <remarks>bla bla bla </remarks>
-        /// <return>UserGroups List</return>
-        /// <response code="200"></response>
-        [Produces("application/json", "text/plain")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserGroup>))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getusersingroupbygroupid")]
-        public async Task<IActionResult> GetUsersInGroupByGroupid(int id)
+        [HttpGet("groups/{id}/users")]
+        public async Task<IActionResult> GetUsersInGroupByGroupid([FromRoute]int id)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUsersInGroupLookupByGroupIdQuery
                 { GroupId = id }));
@@ -118,10 +103,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut("updatebygroupid")]
-        public async Task<IActionResult> UpdateByGroupId([FromBody] UpdateUserGroupByGroupIdCommand updateUserGroup)
+        [HttpPut("groups/{id}")]
+        public async Task<IActionResult> UpdateByGroupId([FromRoute] int id,[FromBody] UpdateUserGroupByGroupIdDto updateUserGroupByGroupIdDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateUserGroup));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateUserGroupByGroupIdCommand{Id = id, GroupId = updateUserGroupByGroupIdDto.GroupId, UserIds = updateUserGroupByGroupIdDto.UserIds}));
         }
 
         /// <summary>
@@ -134,9 +119,9 @@ namespace WebAPI.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteUserGroupCommand deleteUserGroup)
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteUserGroup));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteUserGroupCommand{Id = id}));
         }
     }
 }

--- a/WebAPI/Controllers/UserGroupsController.cs
+++ b/WebAPI/Controllers/UserGroupsController.cs
@@ -119,7 +119,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
+        [HttpDelete("{id}")]
         public async Task<IActionResult> Delete([FromRoute] int id)
         {
             return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteUserGroupCommand{Id = id}));

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -24,7 +24,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserDto>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getall")]
+        [HttpGet]
         public async Task<IActionResult> GetList()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUsersQuery()));
@@ -39,7 +39,7 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SelectionItem>))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getuserlookup")]
+        [HttpGet("lookups")]
         public async Task<IActionResult> GetUserLookup()
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserLookupQuery()));
@@ -54,8 +54,8 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UserDto))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpGet("getbyid")]
-        public async Task<IActionResult> GetById(int userId)
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById([FromRoute]int userId)
         {
             return GetResponseOnlyResultData(await Mediator.Send(new GetUserQuery { UserId = userId }));
         }
@@ -84,10 +84,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpPut]
-        public async Task<IActionResult> Update([FromBody] UpdateUserCommand updateUser)
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update([FromRoute] int id,[FromBody] UpdateUserDto updateUserDto)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(updateUser));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new UpdateUserCommand{UserId = id,Email = updateUserDto.Email,FullName = updateUserDto.FullName, MobilePhones = updateUserDto.MobilePhones, Address = updateUserDto.Address,Notes = updateUserDto.Notes}));
         }
 
         /// <summary>
@@ -99,10 +99,10 @@ namespace WebAPI.Controllers
         [Produces("application/json", "text/plain")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [HttpDelete]
-        public async Task<IActionResult> Delete([FromBody] DeleteUserCommand deleteUser)
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(deleteUser));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteUserCommand{Id = id}));
         }
     }
 }

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -12,7 +12,7 @@ namespace WebAPI.Controllers
     /// <summary>
     /// If controller methods will not be Authorize, [AllowAnonymous] is used.
     /// </summary>
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     public class UsersController : BaseApiController
     {

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -5,6 +5,7 @@ using Business.Handlers.Users.Queries;
 using Core.Entities.Dtos;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Entities.Dtos;
 
 namespace WebAPI.Controllers
 {

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -103,7 +103,7 @@ namespace WebAPI.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete([FromRoute] int id)
         {
-            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteUserCommand{Id = id}));
+            return GetResponseOnlyResultMessage(await Mediator.Send(new DeleteUserCommand{ UserId = id }));
         }
     }
 }

--- a/WebAPI/Startup.cs
+++ b/WebAPI/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Business;
 using Business.Helpers;
@@ -83,6 +84,7 @@ namespace WebAPI
             services.AddSwaggerGen(c =>
             {
                 c.IncludeXmlComments(Path.ChangeExtension(typeof(Startup).Assembly.Location, ".xml"));
+                c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
             });
 
             services.AddTransient<FileLogger>();
@@ -129,7 +131,7 @@ namespace WebAPI
 
             app.UseSwaggerUI(c => {
               c.SwaggerEndpoint("v1/swagger.json", "DevArchitecture"); 
-              c.DocExpansion(DocExpansion.None); 
+              c.DocExpansion(DocExpansion.None);
             });
             app.UseCors("AllowOrigin");
 

--- a/WebAPI/Startup.cs
+++ b/WebAPI/Startup.cs
@@ -14,6 +14,8 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -56,6 +58,13 @@ namespace WebAPI
                     options.JsonSerializerOptions.IgnoreNullValues = true;
                 });
 
+            services.AddApiVersioning(v =>
+            {
+                v.DefaultApiVersion = new ApiVersion(1, 0);
+                v.AssumeDefaultVersionWhenUnspecified = true;
+                v.ReportApiVersions = true;
+                v.ApiVersionReader = new HeaderApiVersionReader("x-dev-arch-version");
+            });
 
             services.AddCors(options =>
             {

--- a/WebAPI/Startup.cs
+++ b/WebAPI/Startup.cs
@@ -84,7 +84,6 @@ namespace WebAPI
             services.AddSwaggerGen(c =>
             {
                 c.IncludeXmlComments(Path.ChangeExtension(typeof(Startup).Assembly.Location, ".xml"));
-                c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
             });
 
             services.AddTransient<FileLogger>();

--- a/WebAPI/WebAPI.csproj
+++ b/WebAPI/WebAPI.csproj
@@ -30,6 +30,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
 			<IncludeAssets>all</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
By the API naming conventions,

- URLs should include nouns, not verbs.
- A URL identifies a resource.
- Use plural nouns only for consistency (no singular nouns).

[Reference](https://github.com/WhiteHouse/api-standards)

Also,

- URLs should separated with dash(-) symbol, not with camelCase

So, in this PR, these convention rules are applied.