### PR TITLE
csharp naming conventions added

### DIFF
--- a/Tests/Business/Adapters/PersonManagerTests.cs
+++ b/Tests/Business/Adapters/PersonManagerTests.cs
@@ -65,10 +65,10 @@ namespace Tests.Business.Adapters
         {
             return new ()
             {
-                _birthYear = birthYear,
-                _surname = surname,
-                _name = name,
-                _citizenId = citizenId
+                BirthYear = birthYear,
+                Surname = surname,
+                Name = name,
+                CitizenId = citizenId
             };
         }
     }

--- a/Tests/Business/Adapters/PersonManagerTests.cs
+++ b/Tests/Business/Adapters/PersonManagerTests.cs
@@ -67,8 +67,8 @@ namespace Tests.Business.Adapters
             {
                 _birthYear = birthYear,
                 _surname = surname,
-                Name = _name,
-                CitizenId = _citizenId
+                _name = name,
+                _citizenId = citizenId
             };
         }
     }

--- a/Tests/Business/Adapters/PersonManagerTests.cs
+++ b/Tests/Business/Adapters/PersonManagerTests.cs
@@ -12,10 +12,10 @@ namespace Tests.Business.Adapters
     [TestFixture]
     public class PersonManagerTests
     {
-        private const int BirthYear = 1987;
-        private const string Surname = "Test1";
-        private const string Name = "Test1";
-        private const long CitizenId = 11111111111;
+        private const int _birthYear = 1987;
+        private const string _surname = "Test1";
+        private const string _name = "Test1";
+        private const long _citizenId = 11111111111;
 
         private Mock<IPersonService>? _personService;
         private PersonServiceHelper? _personServiceHelper;
@@ -58,17 +58,17 @@ namespace Tests.Business.Adapters
         }
 
         private static Citizen CreateCitizen(
-            int birthYear = BirthYear,
-            string surname = Surname,
-            string name = Name,
-            long citizenId = CitizenId)
+            int birthYear = _birthYear,
+            string surname = _surname,
+            string name = _name,
+            long citizenId = _citizenId)
         {
             return new ()
             {
-                BirthYear = birthYear,
-                Surname = surname,
-                Name = name,
-                CitizenId = citizenId
+                _birthYear = birthYear,
+                _surname = surname,
+                Name = _name,
+                CitizenId = _citizenId
             };
         }
     }

--- a/Tests/Business/Services/Authentication/TokenTests.cs
+++ b/Tests/Business/Services/Authentication/TokenTests.cs
@@ -14,20 +14,20 @@ namespace Tests.Business.Services.Authentication
     [TestFixture]
     public class TokenTests : BaseIntegrationTest
     {
-        private const string AuthenticationScheme = "Bearer";
-        private const string RequestUri = "api/users/getall";
+        private const string _authenticationScheme = "Bearer";
+        private const string _requestUri = "api/users/getall";
 
         [Test]
         public async Task TokenAuthorizeTest()
         {
             // Arrange
             var token = MockJwtTokens.GenerateJwtToken(ClaimsData.GetClaims());
-            HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthenticationScheme, token);
+            HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_authenticationScheme, token);
             var cache = new MemoryCacheManager();
 
             cache.Add($"{CacheKeys.UserIdForClaim}=1", new List<string>() { "GetUsersQuery" });
             // Act
-            var response = await HttpClient.GetAsync(RequestUri);
+            var response = await HttpClient.GetAsync(_requestUri);
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -40,12 +40,12 @@ namespace Tests.Business.Services.Authentication
 
             // Arrange
             var token = MockJwtTokens.GenerateJwtToken(ClaimsData.GetClaims());
-            HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthenticationScheme, token);
+            HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_authenticationScheme, token);
 
             // Act
             await Task.Delay(delayAmount);
 
-            var response = await HttpClient.GetAsync(RequestUri);
+            var response = await HttpClient.GetAsync(_requestUri);
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/Tests/Helpers/Token/BaseIntegrationTest.cs
+++ b/Tests/Helpers/Token/BaseIntegrationTest.cs
@@ -10,7 +10,7 @@ namespace Tests.Helpers.Token
     [TestFixture]
     public abstract class BaseIntegrationTest : WebApplicationFactory<Startup>
     {
-        private static readonly JwtSecurityTokenHandler _sTokenHandler = new ();
+        private static readonly JwtSecurityTokenHandler s_TokenHandler = new ();
 
         public string Issuer { get; } = "www.devarchitecture.com";
         public string Audience { get; } = "www.devarchitecture.com";

--- a/Tests/Helpers/Token/BaseIntegrationTest.cs
+++ b/Tests/Helpers/Token/BaseIntegrationTest.cs
@@ -10,7 +10,7 @@ namespace Tests.Helpers.Token
     [TestFixture]
     public abstract class BaseIntegrationTest : WebApplicationFactory<Startup>
     {
-        private static readonly JwtSecurityTokenHandler STokenHandler = new ();
+        private static readonly JwtSecurityTokenHandler _sTokenHandler = new ();
 
         public string Issuer { get; } = "www.devarchitecture.com";
         public string Audience { get; } = "www.devarchitecture.com";

--- a/Tests/Helpers/Token/MockJwtTokens.cs
+++ b/Tests/Helpers/Token/MockJwtTokens.cs
@@ -9,12 +9,12 @@ namespace Tests.Helpers.Token
 {
     public static class MockJwtTokens
     {
-        private static readonly JwtSecurityTokenHandler _sTokenHandler = new ();
-        private static string _keyString = "!z2x3C4v5B*_*!z2x3C4v5B*_*";
+        private static readonly JwtSecurityTokenHandler s_tokenHandler = new ();
+        private static string s_keyString = "!z2x3C4v5B*_*!z2x3C4v5B*_*";
 
         static MockJwtTokens()
         {
-            var SKey = Encoding.UTF8.GetBytes(_keyString);
+            var SKey = Encoding.UTF8.GetBytes(s_keyString);
             SecurityKey = new SymmetricSecurityKey(SKey);
             SigningCredentials = new SigningCredentials(SecurityKey, SecurityAlgorithms.HmacSha256Signature);
         }
@@ -26,7 +26,7 @@ namespace Tests.Helpers.Token
 
         public static string GenerateJwtToken(IEnumerable<Claim> claims, double value = 5)
         {
-            return _sTokenHandler.WriteToken(new JwtSecurityToken(Issuer, Audience, claims, DateTime.UtcNow, DateTime.UtcNow.AddSeconds(value), SigningCredentials));
+            return s_tokenHandler.WriteToken(new JwtSecurityToken(Issuer, Audience, claims, DateTime.UtcNow, DateTime.UtcNow.AddSeconds(value), SigningCredentials));
         }
     }
 }

--- a/Tests/Helpers/Token/MockJwtTokens.cs
+++ b/Tests/Helpers/Token/MockJwtTokens.cs
@@ -9,7 +9,7 @@ namespace Tests.Helpers.Token
 {
     public static class MockJwtTokens
     {
-        private static readonly JwtSecurityTokenHandler STokenHandler = new ();
+        private static readonly JwtSecurityTokenHandler _sTokenHandler = new ();
         private static string _keyString = "!z2x3C4v5B*_*!z2x3C4v5B*_*";
 
         static MockJwtTokens()
@@ -26,7 +26,7 @@ namespace Tests.Helpers.Token
 
         public static string GenerateJwtToken(IEnumerable<Claim> claims, double value = 5)
         {
-            return STokenHandler.WriteToken(new JwtSecurityToken(Issuer, Audience, claims, DateTime.UtcNow, DateTime.UtcNow.AddSeconds(value), SigningCredentials));
+            return _sTokenHandler.WriteToken(new JwtSecurityToken(Issuer, Audience, claims, DateTime.UtcNow, DateTime.UtcNow.AddSeconds(value), SigningCredentials));
         }
     }
 }


### PR DESCRIPTION
By the [.NET documentation](https://github.com/dotnet/corefx/blob/368fdfd86ee3a3bf1bca2a6c339ee590f3d6505d/Documentation/coding-guidelines/coding-style.md), private fields should start with `_`(underscore) and should use camel case. Also, static fields should start with `s_`. Some places  in this repository(especially Tests folder) violate this rule. By the way, i changed these places.